### PR TITLE
Adds custom order status "Ready for Pickup"

### DIFF
--- a/admin/class-local-pickup-time-admin.php
+++ b/admin/class-local-pickup-time-admin.php
@@ -74,6 +74,12 @@ class Local_Pickup_Time_Admin {
 		add_action( 'manage_edit-shop_order_sortable_columns', array( $this, 'add_orders_list_pickup_date_column_sorting' ) );
 		add_action( 'pre_get_posts', array( $this, 'filter_orders_list_by_pickup_date' ) );
 
+		/*
+		 * Add custom order status
+		 */
+		add_action( 'init', array( $this, 'register_ready_for_pickup_order_status' ) );
+		add_filter( 'wc_order_statuses', array( $this, 'add_ready_for_pickup_order_status' ), 10, 1 );
+
 	}
 
 	/**
@@ -445,6 +451,37 @@ class Local_Pickup_Time_Admin {
 		// Call the Public plugin instance of this method to reduce code redundancy.
 		return $plugin->pickup_time_select_translatable( $value );
 
+	}
+
+	/**
+	 * Adds a custom order status for when items are ready for pickup
+	 * 
+	 * @since 1.3.12
+	 *
+	 * @return void
+	 */
+	public function register_ready_for_pickup_order_status() {
+		register_post_status( 'wc-ready-for-pickup', array(
+			'label'                     => 'Ready for Pickup',
+			'public'                    => true,
+			'exclude_from_search'       => false,
+			'show_in_admin_all_list'    => true,
+			'show_in_admin_status_list' => true,
+			'label_count'               => _n_noop( 'Ready for Pickup (%s)', 'Ready for Pickup (%s)' )
+		) );
+	}
+
+	public function add_ready_for_pickup_order_status( $order_statuses ) { 
+		$new_order_statuses = array();
+	
+		// Add new order status after the "Processing" status
+		foreach ( $order_statuses as $key => $status ) {
+			$new_order_statuses[ $key ] = $status;
+			if ( 'wc-processing' === $key ) {
+				$new_order_statuses['wc-ready-for-pickup'] = 'Ready for Pickup';
+			}
+		}
+		return $new_order_statuses;
 	}
 
 }


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [plugin Contributing guideline](https://github.com/mattbanks/woocommerce-local-pickup-time/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This is a start at implementing #7 

This PR adds a custom order status "Ready for Pickup" to the order statuses for WooCommerce.

As I see it, here is what remains to be done:

1. Hook on payment complete and use `wp_schedule_single_event` to schedule the order status change to "Ready for Pickup"
2. Create a new custom email class to allow for users to customize the ready for pickup email (looking at [this](https://www.skyverge.com/blog/how-to-add-a-custom-woocommerce-email/) for inspiration)
3. Perhaps the automatic order status transition should be an option on the settings page?

### How to test the changes in this Pull Request:

1. Create an order
2. Change order status to "Ready for Pickup" in backend

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Adds "ready for pickup" order status
