### PR TITLE
Do not take into account days that open and close at the same time

### DIFF
--- a/public/class-local-pickup-time.php
+++ b/public/class-local-pickup-time.php
@@ -563,7 +563,8 @@ class Local_Pickup_Time {
 			if (
 				! in_array( $pickup_datetime->format( 'm/d/Y' ), $dates_closed, true ) &&
 				! empty( $pickup_day_open_time ) &&
-				! empty( $pickup_day_close_time )
+				! empty( $pickup_day_close_time ) &&
+				$pickup_day_open_time !== $pickup_day_close_time
 			) {
 
 				// Get the intervals for the day and merge the results with the previous array of intervals.


### PR DESCRIPTION
Hi,

Waiting for #87 to be addressed, I would suggest this small addition to disable days with same open and close time. Anyway it could be seen as something logical because if you open and close at the same time then you don't stay opened enough to allow any pick-up ;)

And thanks very much for this plugin !

Séb.

### All Submissions:

* [ ] Have you followed the [plugin Contributing guideline](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/pulls)) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
