### PR TITLE
Markup inconsistency and duplicate sentence

### DIFF
--- a/public/class-local-pickup-time.php
+++ b/public/class-local-pickup-time.php
@@ -684,14 +684,14 @@ class Local_Pickup_Time {
 			'h2' => array(),
 		);
 
-		echo wp_kses( '<div id="local-pickup-time-select"><h2>' . __( 'Pickup Time', 'woocommerce-local-pickup-time' ) . '</h2>', $allowed_html );
+		echo wp_kses( '<div id="local-pickup-time-select"><h3>' . __( 'Pickup Time', 'woocommerce-local-pickup-time' ) . '</h3>', $allowed_html );
 
 		woocommerce_form_field(
 			$this->get_order_post_key(),
 			array(
 				'type'     => 'select',
 				'class'    => array( 'local-pickup-time-select-field form-row-wide' ),
-				'label'    => __( 'Pickup Time', 'woocommerce-local-pickup-time' ),
+				'label'    => __( 'Select time', 'woocommerce-local-pickup-time' ),
 				'required' => true,
 				'options'  => $this->get_pickup_time_options(),
 			),


### PR DESCRIPTION
Hi,

Here I replaced a `<h2>` with a `<h3>` to stay consistent with WooCommerce markup on checkout page.

I also replaced the second "Pickup Time" with "Select time", a string used elsewhere in the plugin, because as it is now you have twice the same sentence appearing one after the other : "Pickup Time" as a title then as a field label. And there is no other way to avoid this...

Thanks again !

Séb.

### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/pulls)) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
