### PR TITLE
Fixes Grunt Configuration for Automated Releases by Tags

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -222,7 +222,7 @@ module.exports = function (grunt) {
 	grunt.registerTask('readme', ['wp_readme_to_markdown']);
 	grunt.registerTask('test', ['checktextdomain', 'phpcs']);
 	grunt.registerTask('build', ['gitinfo', 'test', 'i18n', 'readme']);
-	grunt.registerTask('release', ['checkbranch:main', 'checkrepo', 'gitinfo', 'checktextdomain', 'clean', 'copy']);
+	grunt.registerTask('release', ['checkbranch:HEAD', 'checkrepo', 'gitinfo', 'checktextdomain', 'clean', 'copy']);
 
 };
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -135,7 +135,9 @@ module.exports = function (grunt) {
 		checkrepo: {
 			deploy: {
 				tagged: true, // Check that the last commit (HEAD) is tagged
-				clean: true // Check that working directory is clean
+				tag: {
+					eq: '<%= pkg.version %>' // Check if highest repo tag is equal to pkg.version
+				}
 			}
 		},
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/pulls)) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Fixes Grunt Release Task to Run on HEAD for GitHub Action (#120)
- Fixes Grunt Release Configuration for Automated Releases

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
