### PR TITLE
Fix textdomain

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,26 +4,26 @@ This plugin enhances WooCommerce, and your help making it even more awesome will
 
 There are many ways to contribute to the project!
 
-- [Translating strings into your language](https://translate.wordpress.org/projects/wp-plugins/woocommerce-local-pickup-time-select/).
-- Answering questions on the [WP.org support forums](https://wordpress.org/support/plugin/woocommerce-local-pickup-time-select/).
-- Testing open [issues](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/issues) or [pull requests](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/pulls) and sharing your findings in a comment.
+- [Translating strings into your language](https://translate.wordpress.org/projects/wp-plugins/woocommerce-local-pickup-time-select-select/).
+- Answering questions on the [WP.org support forums](https://wordpress.org/support/plugin/woocommerce-local-pickup-time-select-select/).
+- Testing open [issues](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select/issues) or [pull requests](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select/pulls) and sharing your findings in a comment.
 - Submitting fixes, improvements, and enhancements.
 - To disclose a security issue to our team.
 
 If you wish to contribute code, please read the information in the sections below. Then [fork](https://help.github.com/articles/fork-a-repo/) the plugin, commit your changes, and [submit a pull request](https://help.github.com/articles/using-pull-requests/) 🎉
 
-We use the `good first issue` label to mark issues that are suitable for new contributors. You can find all the issues with this label [here](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+We use the `good first issue` label to mark issues that are suitable for new contributors. You can find all the issues with this label [here](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 WooCommerce Local Pickup Time is licensed under the GPLv2.0, and all contributions to the project will be released under the same license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2.0 license.
 
 ## Getting started
 
-- [How to set up the plugin development environment](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/wiki/How-to-setup-the-plugin-development-environment)
+- [How to set up the plugin development environment](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select/wiki/How-to-setup-the-plugin-development-environment)
 
 ## Coding Guidelines and Development 🛠
 
 - Ensure you stick to the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/)
-- Run our build process described in the document on [How to setup the plugin development environment](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/wiki/How-to-setup-the-plugin-development-environment), it will install everything needed to do development on our plugin.
+- Run our build process described in the document on [How to setup the plugin development environment](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select/wiki/How-to-setup-the-plugin-development-environment), it will install everything needed to do development on our plugin.
 - Whenever possible please fix pre-existing code standards errors in the files that you change. It is ok to skip that for larger files or complex fixes.
 - Ensure you use LF line endings in your code editor. Use [EditorConfig](http://editorconfig.org/) if your editor supports it so that indentation, line endings and other settings are auto configured.
 - When committing, reference your issue number (#1234) and include a note about the fix.
@@ -34,4 +34,4 @@ WooCommerce Local Pickup Time is licensed under the GPLv2.0, and all contributio
 
 ## Feature Requests 🚀
 
-Feature requests can be [submitted to our issue tracker](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/issues/new?template=5-Feature-request.md). Be sure to include a description of the expected behavior and use case, and before submitting a request, please search for similar ones in the closed issues.
+Feature requests can be [submitted to our issue tracker](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select/issues/new?template=5-Feature-request.md). Be sure to include a description of the expected behavior and use case, and before submitting a request, please search for similar ones in the closed issues.

--- a/.github/ISSUE_TEMPLATE/2-Support.md
+++ b/.github/ISSUE_TEMPLATE/2-Support.md
@@ -8,4 +8,4 @@ assignees: ''
 ---
 
 **General usage questions**
-If your question hasn't been answered in the Wiki please check the [Discussions](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/discussions) for possible solutions or post a new question there.
+If your question hasn't been answered in the Wiki please check the [Discussions](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select/discussions) for possible solutions or post a new question there.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 ### All Submissions:
 
-* [ ] Have you followed the [plugin Contributing guideline](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/blob/master/.github/CONTRIBUTING.md)?
+* [ ] Have you followed the [plugin Contributing guideline](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select/blob/master/.github/CONTRIBUTING.md)?
 * [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
-* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/pulls)) for the same update/change?
+* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select/pulls)) for the same update/change?
 
 <!-- Mark completed items with an [x] -->
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,4 +49,4 @@ jobs:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SOURCE_DIR: dist/
-        SLUG: woocommerce-local-pickup-time-select
+        SLUG: woocommerce-local-pickup-time-select-select

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,7 +80,7 @@ module.exports = function (grunt) {
 
 		addtextdomain: {
 			options: {
-				textdomain: 'woocommerce-local-pickup-time',    // Project text domain.
+				textdomain: 'woocommerce-local-pickup-time-select',    // Project text domain.
 			},
 			update_all_domains: {
 				options: {
@@ -112,8 +112,8 @@ module.exports = function (grunt) {
 						'vendor/.*', 							//composer
 						'wordpress/.*',
 					],                                // List of files or directories to ignore.
-					mainFile: 'woocommerce-local-pickup-time.php',                     // Main project file.
-					potFilename: 'woocommerce-local-pickup-time.pot',                  // Name of the POT file.
+					mainFile: 'woocommerce-local-pickup-time-select.php',                     // Main project file.
+					potFilename: 'woocommerce-local-pickup-time-select.pot',                  // Name of the POT file.
 					potHeaders: {
 						poedit: true,                 // Includes common Poedit headers.
 						'x-poedit-keywordslist': true // Include a list of all possible gettext functions.
@@ -143,7 +143,7 @@ module.exports = function (grunt) {
 
 		checktextdomain: {
 			options: {
-				text_domain: 'woocommerce-local-pickup-time',
+				text_domain: 'woocommerce-local-pickup-time-select',
 				keywords: [
 					'__:1,2d',
 					'_e:1,2d',
@@ -204,8 +204,8 @@ module.exports = function (grunt) {
 		wp_deploy: {
 			deploy: {
 				options: {
-					plugin_slug: 'woocommerce-local-pickup-time-select',
-					plugin_main_file: 'woocommerce-local-pickup-time.php',
+					plugin_slug: 'woocommerce-local-pickup-time-select-select',
+					plugin_main_file: 'woocommerce-local-pickup-time-select.php',
 					build_dir: 'dist/',
 					assets_dir: '.wordpress-org/',
 					max_buffer: 1024 * 1024,

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In the admin area, under WooCommerce -> Settings -> General, you can set the sta
 ### Using The WordPress Dashboard ###
 
 1. Navigate to the 'Add New' in the plugins dashboard
-2. Search for 'woocommerce-local-pickup-time'
+2. Search for 'woocommerce-local-pickup-time-select'
 3. Click 'Install Now'
 4. Activate the plugin on the Plugin dashboard
 
@@ -32,15 +32,15 @@ In the admin area, under WooCommerce -> Settings -> General, you can set the sta
 
 1. Navigate to the 'Add New' in the plugins dashboard
 2. Navigate to the 'Upload' area
-3. Select `woocommerce-local-pickup-time.zip` from your computer
+3. Select `woocommerce-local-pickup-time-select.zip` from your computer
 4. Click 'Install Now'
 5. Activate the plugin in the Plugin dashboard
 
 ### Using FTP ###
 
-1. Download `woocommerce-local-pickup-time.zip`
-2. Extract the `woocommerce-local-pickup-time` directory to your computer
-3. Upload the `woocommerce-local-pickup-time` directory to the `/wp-content/plugins/` directory
+1. Download `woocommerce-local-pickup-time-select.zip`
+2. Extract the `woocommerce-local-pickup-time-select` directory to your computer
+3. Upload the `woocommerce-local-pickup-time-select` directory to the `/wp-content/plugins/` directory
 4. Activate the plugin in the Plugin dashboard
 
 # Usage #

--- a/admin/class-local-pickup-time-admin.php
+++ b/admin/class-local-pickup-time-admin.php
@@ -93,14 +93,14 @@ class Local_Pickup_Time_Admin {
 
 		$updated_settings[] = array(
 			array(
-				'title' => __( 'Store Hours and Closings for Local Pickup', 'woocommerce-local-pickup-time' ),
+				'title' => __( 'Store Hours and Closings for Local Pickup', 'woocommerce-local-pickup-time-select' ),
 				'type'  => 'title',
-				'desc'  => __( 'The following options affect when order pickups begin and end each day, and which days to not allow order pickups.', 'woocommerce-local-pickup-time' ),
+				'desc'  => __( 'The following options affect when order pickups begin and end each day, and which days to not allow order pickups.', 'woocommerce-local-pickup-time-select' ),
 				'id'    => 'local_pickup_hours',
 			),
 			array(
-				'title'    => __( 'Monday Pickup Start Time (use 24-hour time)', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'This sets the pickup start time for Monday. Use 24-hour time format.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Monday Pickup Start Time (use 24-hour time)', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'This sets the pickup start time for Monday. Use 24-hour time format.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_monday_start',
 				'css'      => 'width:120px;',
 				'default'  => '10:00',
@@ -108,8 +108,8 @@ class Local_Pickup_Time_Admin {
 				'desc_tip' => true,
 			),
 			array(
-				'title'    => __( 'Monday Pickup End Time (use 24-hour time)', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'This sets the pickup end time for Monday. Use 24-hour time format.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Monday Pickup End Time (use 24-hour time)', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'This sets the pickup end time for Monday. Use 24-hour time format.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_monday_end',
 				'css'      => 'width:120px;',
 				'default'  => '19:00',
@@ -117,8 +117,8 @@ class Local_Pickup_Time_Admin {
 				'desc_tip' => true,
 			),
 			array(
-				'title'    => __( 'Tuesday Pickup Start Time (use 24-hour time)', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'This sets the pickup start time for Tuesday. Use 24-hour time format.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Tuesday Pickup Start Time (use 24-hour time)', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'This sets the pickup start time for Tuesday. Use 24-hour time format.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_tuesday_start',
 				'css'      => 'width:120px;',
 				'default'  => '10:00',
@@ -126,8 +126,8 @@ class Local_Pickup_Time_Admin {
 				'desc_tip' => true,
 			),
 			array(
-				'title'    => __( 'Tuesday Pickup End Time (use 24-hour time)', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'This sets the pickup end time for Tuesday. Use 24-hour time format.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Tuesday Pickup End Time (use 24-hour time)', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'This sets the pickup end time for Tuesday. Use 24-hour time format.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_tuesday_end',
 				'css'      => 'width:120px;',
 				'default'  => '19:00',
@@ -135,8 +135,8 @@ class Local_Pickup_Time_Admin {
 				'desc_tip' => true,
 			),
 			array(
-				'title'    => __( 'Wednesday Pickup Start Time (use 24-hour time)', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'This sets the pickup start time for Wednesday. Use 24-hour time format.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Wednesday Pickup Start Time (use 24-hour time)', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'This sets the pickup start time for Wednesday. Use 24-hour time format.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_wednesday_start',
 				'css'      => 'width:120px;',
 				'default'  => '10:00',
@@ -144,8 +144,8 @@ class Local_Pickup_Time_Admin {
 				'desc_tip' => true,
 			),
 			array(
-				'title'    => __( 'Wednesday Pickup End Time (use 24-hour time)', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'This sets the pickup end time for Wednesday. Use 24-hour time format.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Wednesday Pickup End Time (use 24-hour time)', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'This sets the pickup end time for Wednesday. Use 24-hour time format.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_wednesday_end',
 				'css'      => 'width:120px;',
 				'default'  => '19:00',
@@ -153,8 +153,8 @@ class Local_Pickup_Time_Admin {
 				'desc_tip' => true,
 			),
 			array(
-				'title'    => __( 'Thursday Pickup Start Time (use 24-hour time)', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'This sets the pickup start time for Thursday. Use 24-hour time format.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Thursday Pickup Start Time (use 24-hour time)', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'This sets the pickup start time for Thursday. Use 24-hour time format.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_thursday_start',
 				'css'      => 'width:120px;',
 				'default'  => '10:00',
@@ -162,8 +162,8 @@ class Local_Pickup_Time_Admin {
 				'desc_tip' => true,
 			),
 			array(
-				'title'    => __( 'Thursday Pickup End Time (use 24-hour time)', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'This sets the pickup end time for Thursday. Use 24-hour time format.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Thursday Pickup End Time (use 24-hour time)', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'This sets the pickup end time for Thursday. Use 24-hour time format.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_thursday_end',
 				'css'      => 'width:120px;',
 				'default'  => '19:00',
@@ -171,8 +171,8 @@ class Local_Pickup_Time_Admin {
 				'desc_tip' => true,
 			),
 			array(
-				'title'    => __( 'Friday Pickup Start Time (use 24-hour time)', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'This sets the pickup start time for Friday. Use 24-hour time format.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Friday Pickup Start Time (use 24-hour time)', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'This sets the pickup start time for Friday. Use 24-hour time format.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_friday_start',
 				'css'      => 'width:120px;',
 				'default'  => '10:00',
@@ -180,8 +180,8 @@ class Local_Pickup_Time_Admin {
 				'desc_tip' => true,
 			),
 			array(
-				'title'    => __( 'Friday Pickup End Time (use 24-hour time)', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'This sets the pickup end time for Friday. Use 24-hour time format.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Friday Pickup End Time (use 24-hour time)', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'This sets the pickup end time for Friday. Use 24-hour time format.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_friday_end',
 				'css'      => 'width:120px;',
 				'default'  => '19:00',
@@ -189,8 +189,8 @@ class Local_Pickup_Time_Admin {
 				'desc_tip' => true,
 			),
 			array(
-				'title'    => __( 'Saturday Pickup Start Time (use 24-hour time)', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'This sets the pickup start time for Saturday. Use 24-hour time format.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Saturday Pickup Start Time (use 24-hour time)', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'This sets the pickup start time for Saturday. Use 24-hour time format.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_saturday_start',
 				'css'      => 'width:120px;',
 				'default'  => '10:00',
@@ -198,8 +198,8 @@ class Local_Pickup_Time_Admin {
 				'desc_tip' => true,
 			),
 			array(
-				'title'    => __( 'Saturday Pickup End Time (use 24-hour time)', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'This sets the pickup end time for Saturday. Use 24-hour time format.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Saturday Pickup End Time (use 24-hour time)', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'This sets the pickup end time for Saturday. Use 24-hour time format.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_saturday_end',
 				'css'      => 'width:120px;',
 				'default'  => '19:00',
@@ -207,8 +207,8 @@ class Local_Pickup_Time_Admin {
 				'desc_tip' => true,
 			),
 			array(
-				'title'    => __( 'Sunday Pickup Start Time (use 24-hour time)', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'This sets the pickup start time for Sunday. Use 24-hour time format.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Sunday Pickup Start Time (use 24-hour time)', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'This sets the pickup start time for Sunday. Use 24-hour time format.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_sunday_start',
 				'css'      => 'width:120px;',
 				'default'  => '10:00',
@@ -216,8 +216,8 @@ class Local_Pickup_Time_Admin {
 				'desc_tip' => true,
 			),
 			array(
-				'title'    => __( 'Sunday Pickup End Time (use 24-hour time)', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'This sets the pickup end time for Sunday. Use 24-hour time format.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Sunday Pickup End Time (use 24-hour time)', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'This sets the pickup end time for Sunday. Use 24-hour time format.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_sunday_end',
 				'css'      => 'width:120px;',
 				'default'  => '19:00',
@@ -225,8 +225,8 @@ class Local_Pickup_Time_Admin {
 				'desc_tip' => true,
 			),
 			array(
-				'title'    => __( 'Store Closing Days (use MM/DD/YYYY format)', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'This sets the days the store is closed. Enter one date per line, in format MM/DD/YYYY.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Store Closing Days (use MM/DD/YYYY format)', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'This sets the days the store is closed. Enter one date per line, in format MM/DD/YYYY.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_closings',
 				'css'      => 'width:250px;height:150px;',
 				'default'  => '01/01/2014',
@@ -234,8 +234,8 @@ class Local_Pickup_Time_Admin {
 				'desc_tip' => true,
 			),
 			array(
-				'title'    => __( 'Pickup Time Interval', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'Choose the time interval for allowing local pickup orders.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Pickup Time Interval', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'Choose the time interval for allowing local pickup orders.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_hours_interval',
 				'css'      => 'width:100px;',
 				'default'  => '30',
@@ -243,19 +243,19 @@ class Local_Pickup_Time_Admin {
 				'class'    => 'chosen_select',
 				'desc_tip' => true,
 				'options'  => array(
-					'5'   => __( '5 minutes', 'woocommerce-local-pickup-time' ),
-					'10'  => __( '10 minutes', 'woocommerce-local-pickup-time' ),
-					'15'  => __( '15 minutes', 'woocommerce-local-pickup-time' ),
-					'20'  => __( '20 minutes', 'woocommerce-local-pickup-time' ),
-					'30'  => __( '30 minutes', 'woocommerce-local-pickup-time' ),
-					'45'  => __( '45 minutes', 'woocommerce-local-pickup-time' ),
-					'60'  => __( '1 hour', 'woocommerce-local-pickup-time' ),
-					'120' => __( '2 hours', 'woocommerce-local-pickup-time' ),
+					'5'   => __( '5 minutes', 'woocommerce-local-pickup-time-select' ),
+					'10'  => __( '10 minutes', 'woocommerce-local-pickup-time-select' ),
+					'15'  => __( '15 minutes', 'woocommerce-local-pickup-time-select' ),
+					'20'  => __( '20 minutes', 'woocommerce-local-pickup-time-select' ),
+					'30'  => __( '30 minutes', 'woocommerce-local-pickup-time-select' ),
+					'45'  => __( '45 minutes', 'woocommerce-local-pickup-time-select' ),
+					'60'  => __( '1 hour', 'woocommerce-local-pickup-time-select' ),
+					'120' => __( '2 hours', 'woocommerce-local-pickup-time-select' ),
 				),
 			),
 			array(
-				'title'    => __( 'Pickup Time Delay', 'woocommerce-local-pickup-time' ),
-				'desc'     => __( 'Choose the time delay from the time of ordering for allowing local pickup orders.', 'woocommerce-local-pickup-time' ),
+				'title'    => __( 'Pickup Time Delay', 'woocommerce-local-pickup-time-select' ),
+				'desc'     => __( 'Choose the time delay from the time of ordering for allowing local pickup orders.', 'woocommerce-local-pickup-time-select' ),
 				'id'       => 'local_pickup_delay_minutes',
 				'css'      => 'width:100px;',
 				'default'  => '60',
@@ -263,28 +263,28 @@ class Local_Pickup_Time_Admin {
 				'class'    => 'chosen_select',
 				'desc_tip' => true,
 				'options'  => array(
-					'5'     => __( '5 minutes', 'woocommerce-local-pickup-time' ),
-					'10'    => __( '10 minutes', 'woocommerce-local-pickup-time' ),
-					'15'    => __( '15 minutes', 'woocommerce-local-pickup-time' ),
-					'20'    => __( '20 minutes', 'woocommerce-local-pickup-time' ),
-					'30'    => __( '30 minutes', 'woocommerce-local-pickup-time' ),
-					'45'    => __( '45 minutes', 'woocommerce-local-pickup-time' ),
-					'60'    => __( '1 hour', 'woocommerce-local-pickup-time' ),
-					'120'   => __( '2 hours', 'woocommerce-local-pickup-time' ),
-					'240'   => __( '4 hours', 'woocommerce-local-pickup-time' ),
-					'480'   => __( '8 hours', 'woocommerce-local-pickup-time' ),
-					'960'   => __( '16 hours', 'woocommerce-local-pickup-time' ),
-					'1440'  => __( '24 hours', 'woocommerce-local-pickup-time' ),
-					'2160'  => __( '36 hours', 'woocommerce-local-pickup-time' ),
-					'2880'  => __( '48 hours', 'woocommerce-local-pickup-time' ),
-					'4320'  => __( '3 days', 'woocommerce-local-pickup-time' ),
-					'7200'  => __( '5 days', 'woocommerce-local-pickup-time' ),
-					'10080' => __( '1 week', 'woocommerce-local-pickup-time' ),
+					'5'     => __( '5 minutes', 'woocommerce-local-pickup-time-select' ),
+					'10'    => __( '10 minutes', 'woocommerce-local-pickup-time-select' ),
+					'15'    => __( '15 minutes', 'woocommerce-local-pickup-time-select' ),
+					'20'    => __( '20 minutes', 'woocommerce-local-pickup-time-select' ),
+					'30'    => __( '30 minutes', 'woocommerce-local-pickup-time-select' ),
+					'45'    => __( '45 minutes', 'woocommerce-local-pickup-time-select' ),
+					'60'    => __( '1 hour', 'woocommerce-local-pickup-time-select' ),
+					'120'   => __( '2 hours', 'woocommerce-local-pickup-time-select' ),
+					'240'   => __( '4 hours', 'woocommerce-local-pickup-time-select' ),
+					'480'   => __( '8 hours', 'woocommerce-local-pickup-time-select' ),
+					'960'   => __( '16 hours', 'woocommerce-local-pickup-time-select' ),
+					'1440'  => __( '24 hours', 'woocommerce-local-pickup-time-select' ),
+					'2160'  => __( '36 hours', 'woocommerce-local-pickup-time-select' ),
+					'2880'  => __( '48 hours', 'woocommerce-local-pickup-time-select' ),
+					'4320'  => __( '3 days', 'woocommerce-local-pickup-time-select' ),
+					'7200'  => __( '5 days', 'woocommerce-local-pickup-time-select' ),
+					'10080' => __( '1 week', 'woocommerce-local-pickup-time-select' ),
 				),
 			),
 			array(
-				'title'       => __( 'Pickup Time Open Days Ahead', 'woocommerce-local-pickup-time' ),
-				'desc'        => __( 'Choose the number of open days ahead for allowing local pickup orders. This is inclusive of the current day, if timeslots are still available.', 'woocommerce-local-pickup-time' ),
+				'title'       => __( 'Pickup Time Open Days Ahead', 'woocommerce-local-pickup-time-select' ),
+				'desc'        => __( 'Choose the number of open days ahead for allowing local pickup orders. This is inclusive of the current day, if timeslots are still available.', 'woocommerce-local-pickup-time-select' ),
 				'id'          => 'local_pickup_days_ahead',
 				'css'         => 'width:100px;',
 				'default'     => '1',
@@ -329,7 +329,7 @@ class Local_Pickup_Time_Admin {
 			'strong' => array(),
 		);
 
-		echo wp_kses( '<p><strong>' . __( 'Pickup Time:', 'woocommerce-local-pickup-time' ) . '</strong> ' . esc_html( $this->pickup_time_select_translatable( $pickup_time ) ) . '</p>', $allowed_html );
+		echo wp_kses( '<p><strong>' . __( 'Pickup Time:', 'woocommerce-local-pickup-time-select' ) . '</strong> ' . esc_html( $this->pickup_time_select_translatable( $pickup_time ) ) . '</p>', $allowed_html );
 
 	}
 
@@ -350,7 +350,7 @@ class Local_Pickup_Time_Admin {
 			$new_columns[ $column_name ] = $column_info;
 
 			if ( 'order_date' === $column_name ) {
-				$new_columns[ $this->plugin->get_order_meta_key() ] = __( 'Pickup Time', 'woocommerce-local-pickup-time' );
+				$new_columns[ $this->plugin->get_order_meta_key() ] = __( 'Pickup Time', 'woocommerce-local-pickup-time-select' );
 			}
 		}
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-	"name": "wc-local-pickup/woocommerce-local-pickup-time",
+	"name": "wc-local-pickup/woocommerce-local-pickup-time-select",
 	"description": "Add an an option to WooCommerce checkout pages for Local Pickup that allows the user to choose a pickup time.",
 	"type": "wordpress-plugin",
-	"homepage": "https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time",
+	"homepage": "https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select",
 	"license": "GPL-2.0-or-later",
 	"authors": [
 		{
@@ -64,7 +64,7 @@
 	},
 	"autoload-dev": {
 		"classmap": [
-			"woocommerce-local-pickup-time.php",
+			"woocommerce-local-pickup-time-select.php",
 			"admin/class-local-pickup-time-admin.php",
 			"public/class-local-pickup-time.php",
 			"wordpress/src/",
@@ -82,7 +82,7 @@
 	},
 	"autoload": {
 		"classmap": [
-			"woocommerce-local-pickup-time.php",
+			"woocommerce-local-pickup-time-select.php",
 			"admin/class-local-pickup-time-admin.php",
 			"public/class-local-pickup-time.php"
 		],

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -12,7 +12,7 @@ services:
 
     volumes:
       - ../tools/local-env/default.template:/etc/nginx/conf.d/default.template
-      - ..:/var/www/${LOCAL_DIR-src}/wp-content/plugins/woocommerce-local-pickup-time-select
+      - ..:/var/www/${LOCAL_DIR-src}/wp-content/plugins/woocommerce-local-pickup-time-select-select
       - ../vendor/woocommerce/woocommerce:/var/www/${LOCAL_DIR-src}/wp-content/plugins/woocommerce
       - ../tools/local-env/mu-plugins:/var/www/${LOCAL_DIR-src}/wp-content/mu-plugins
 
@@ -29,7 +29,7 @@ services:
       SMTP_PORT: ${SMTP_PORT-1025}
 
     volumes:
-      - ..:/var/www/${LOCAL_DIR-src}/wp-content/plugins/woocommerce-local-pickup-time-select
+      - ..:/var/www/${LOCAL_DIR-src}/wp-content/plugins/woocommerce-local-pickup-time-select-select
       - ../vendor/woocommerce/woocommerce:/var/www/${LOCAL_DIR-src}/wp-content/plugins/woocommerce
       - ../tools/local-env/mu-plugins:/var/www/${LOCAL_DIR-src}/wp-content/mu-plugins
 
@@ -43,7 +43,7 @@ services:
       SMTP_PORT: ${SMTP_PORT-1025}
 
     volumes:
-      - ..:/var/www/${LOCAL_DIR-src}/wp-content/plugins/woocommerce-local-pickup-time-select
+      - ..:/var/www/${LOCAL_DIR-src}/wp-content/plugins/woocommerce-local-pickup-time-select-select
       - ../vendor/woocommerce/woocommerce:/var/www/${LOCAL_DIR-src}/wp-content/plugins/woocommerce
       - ../tools/local-env/mu-plugins:/var/www/${LOCAL_DIR-src}/wp-content/mu-plugins
 
@@ -61,7 +61,7 @@ services:
       SMTP_PORT: ${SMTP_PORT-1025}
 
     volumes:
-      - ..:/var/www/${LOCAL_DIR-src}/wp-content/plugins/woocommerce-local-pickup-time-select
+      - ..:/var/www/${LOCAL_DIR-src}/wp-content/plugins/woocommerce-local-pickup-time-select-select
       - ../vendor/woocommerce/woocommerce:/var/www/${LOCAL_DIR-src}/wp-content/plugins/woocommerce
       - ../tools/local-env/mu-plugins:/var/www/${LOCAL_DIR-src}/wp-content/mu-plugins
 

--- a/languages/woocommerce-local-pickup-time-cs_CZ.po
+++ b/languages/woocommerce-local-pickup-time-cs_CZ.po
@@ -344,7 +344,7 @@ msgid "WooCommerce Local Pickup Time Select"
 msgstr "WooCommerce Local Pickup Time Select"
 
 #. Plugin URI of the plugin/theme
-msgid "https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time"
+msgid "https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select"
 msgstr ""
 
 #. Description of the plugin/theme

--- a/languages/woocommerce-local-pickup-time-en_US.po
+++ b/languages/woocommerce-local-pickup-time-en_US.po
@@ -317,7 +317,7 @@ msgid "WooCommerce Local Pickup Time Select"
 msgstr ""
 
 #. Plugin URI of the plugin/theme
-msgid "https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time"
+msgid "https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select"
 msgstr ""
 
 #. Description of the plugin/theme

--- a/languages/woocommerce-local-pickup-time.pot
+++ b/languages/woocommerce-local-pickup-time.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WooCommerce Local Pickup Time Select 1.3.13\n"
 "Report-Msgid-Bugs-To: "
-"https://wordpress.org/support/plugin/woocommerce-local-pickup-time\n"
+"https://wordpress.org/support/plugin/woocommerce-local-pickup-time-select\n"
 "POT-Creation-Date: 2021-03-18 01:26:39+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
@@ -322,7 +322,7 @@ msgid "WooCommerce Local Pickup Time Select"
 msgstr ""
 
 #. Plugin URI of the plugin/theme
-msgid "https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time"
+msgid "https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select"
 msgstr ""
 
 #. Description of the plugin/theme

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "woocommerce-local-pickup-time",
+  "name": "woocommerce-local-pickup-time-select",
   "version": "1.3.13",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-	"name": "woocommerce-local-pickup-time",
+	"name": "woocommerce-local-pickup-time-select",
 	"version": "1.3.13",
 	"description": "Add an an option to WooCommerce checkout pages for Local Pickup that allows the user to choose a pickup time.",
 	"main": "Gruntfile.js",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time"
+		"url": "https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select"
 	},
 	"keywords": [
 		"wordpress",
@@ -14,9 +14,9 @@
 	"author": "Tim Nolte",
 	"license": "GPL-2.0+",
 	"bugs": {
-		"url": "https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/issues"
+		"url": "https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select/issues"
 	},
-	"homepage": "https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time#readme",
+	"homepage": "https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select#readme",
 	"dependencies": {
 		"dev-require": "^0.1.0"
 	},
@@ -40,7 +40,7 @@
 		"puppeteer": "^1.20.0"
 	},
 	"wp-env": {
-		"plugin-dir": "woocommerce-local-pickup-time-select",
+		"plugin-dir": "woocommerce-local-pickup-time-select-select",
 		"plugin-name": "WooCommerce Local Pickup Time Select",
 		"docker-template": "./docker-compose.override.yml",
 		"welcome-logo": [

--- a/public/class-local-pickup-time.php
+++ b/public/class-local-pickup-time.php
@@ -38,7 +38,7 @@ class Local_Pickup_Time {
 	 *
 	 * @var      string
 	 */
-	protected $plugin_slug = 'woocommerce-local-pickup-time';
+	protected $plugin_slug = 'woocommerce-local-pickup-time-select';
 
 	/**
 	 * Instance of this class.
@@ -522,13 +522,13 @@ class Local_Pickup_Time {
 		$num_days_ahead      = get_option( 'local_pickup_days_ahead', 1 );
 
 		// Translateble days.
-		__( 'Monday', 'woocommerce-local-pickup-time' );
-		__( 'Tuesday', 'woocommerce-local-pickup-time' );
-		__( 'Wednesday', 'woocommerce-local-pickup-time' );
-		__( 'Thursday', 'woocommerce-local-pickup-time' );
-		__( 'Friday', 'woocommerce-local-pickup-time' );
-		__( 'Saturday', 'woocommerce-local-pickup-time' );
-		__( 'Sunday', 'woocommerce-local-pickup-time' );
+		__( 'Monday', 'woocommerce-local-pickup-time-select' );
+		__( 'Tuesday', 'woocommerce-local-pickup-time-select' );
+		__( 'Wednesday', 'woocommerce-local-pickup-time-select' );
+		__( 'Thursday', 'woocommerce-local-pickup-time-select' );
+		__( 'Friday', 'woocommerce-local-pickup-time-select' );
+		__( 'Saturday', 'woocommerce-local-pickup-time-select' );
+		__( 'Sunday', 'woocommerce-local-pickup-time-select' );
 
 		// Get the current WordPress-based date/time.
 		$current_wp_datetime  = new DateTime( 'now', $this->get_wp_timezone() );
@@ -552,7 +552,7 @@ class Local_Pickup_Time {
 		$pickup_datetime->modify( "+$delay_minutes minute" );
 
 		// Setup options array with empty first item.
-		$pickup_options[''] = __( 'Select time', 'woocommerce-local-pickup-time' );
+		$pickup_options[''] = __( 'Select time', 'woocommerce-local-pickup-time-select' );
 
 		// Initialize firt interval state.
 		$first_interval = true;
@@ -689,14 +689,14 @@ class Local_Pickup_Time {
 			'h2' => array(),
 		);
 
-		echo wp_kses( '<div id="local-pickup-time-select"><h2>' . __( 'Pickup Time', 'woocommerce-local-pickup-time' ) . '</h2>', $allowed_html );
+		echo wp_kses( '<div id="local-pickup-time-select"><h2>' . __( 'Pickup Time', 'woocommerce-local-pickup-time-select' ) . '</h2>', $allowed_html );
 
 		woocommerce_form_field(
 			$this->get_order_post_key(),
 			array(
 				'type'     => 'select',
 				'class'    => array( 'local-pickup-time-select-field form-row-wide' ),
-				'label'    => __( 'Pickup Time', 'woocommerce-local-pickup-time' ),
+				'label'    => __( 'Pickup Time', 'woocommerce-local-pickup-time-select' ),
 				'required' => true,
 				'options'  => $this->get_pickup_time_options(),
 			),
@@ -739,10 +739,10 @@ class Local_Pickup_Time {
 			wp_verify_nonce( sanitize_text_field( stripslashes_from_strings_only( $_REQUEST[ $this->get_order_pickup_time_nonce_key() ] ) ), $this->get_order_pickup_time_action_key() ) == 1 ) {
 			// Check if set, if its not set add an error.
 			if ( empty( wc_get_post_data_by_key( $this->get_order_post_key() ) ) ) {
-				wc_add_notice( __( 'Please select a pickup time.', 'woocommerce-local-pickup-time' ), 'error' );
+				wc_add_notice( __( 'Please select a pickup time.', 'woocommerce-local-pickup-time-select' ), 'error' );
 			}
 		} else {
-			wc_add_notice( __( 'Expired or invalid submission!.', 'woocommerce-local-pickup-time' ), 'error' );
+			wc_add_notice( __( 'Expired or invalid submission!.', 'woocommerce-local-pickup-time-select' ), 'error' );
 		}
 
 	}
@@ -765,7 +765,7 @@ class Local_Pickup_Time {
 				update_post_meta( $order_id, $this->get_order_meta_key(), wc_get_post_data_by_key( $this->get_order_post_key() ) );
 			}
 		} else {
-			wc_add_notice( __( 'Expired or invalid submission!.', 'woocommerce-local-pickup-time' ), 'error' );
+			wc_add_notice( __( 'Expired or invalid submission!.', 'woocommerce-local-pickup-time-select' ), 'error' );
 		}
 
 	}
@@ -784,7 +784,7 @@ class Local_Pickup_Time {
 
 		$value              = $this->pickup_time_select_translatable( get_post_meta( $order->get_id(), $this->get_order_meta_key(), true ) );
 		$fields['meta_key'] = array(
-			'label' => __( 'Pickup Time', 'woocommerce-local-pickup-time' ),
+			'label' => __( 'Pickup Time', 'woocommerce-local-pickup-time-select' ),
 			'value' => $value,
 		);
 
@@ -804,7 +804,7 @@ class Local_Pickup_Time {
 
 		// Only attempt date/time adjustments when a value is set.
 		if ( empty( $value ) ) {
-			return __( 'None', 'woocommerce-local-pickup-time' );
+			return __( 'None', 'woocommerce-local-pickup-time-select' );
 		}
 
 		// This match is specifically to address the bug introduced in 1.3.1.

--- a/readme.txt
+++ b/readme.txt
@@ -24,7 +24,7 @@ In the admin area, under WooCommerce -> Settings -> General, you can set the sta
 = Using The WordPress Dashboard =
 
 1. Navigate to the 'Add New' in the plugins dashboard
-2. Search for 'woocommerce-local-pickup-time'
+2. Search for 'woocommerce-local-pickup-time-select'
 3. Click 'Install Now'
 4. Activate the plugin on the Plugin dashboard
 
@@ -32,15 +32,15 @@ In the admin area, under WooCommerce -> Settings -> General, you can set the sta
 
 1. Navigate to the 'Add New' in the plugins dashboard
 2. Navigate to the 'Upload' area
-3. Select `woocommerce-local-pickup-time.zip` from your computer
+3. Select `woocommerce-local-pickup-time-select.zip` from your computer
 4. Click 'Install Now'
 5. Activate the plugin in the Plugin dashboard
 
 = Using FTP =
 
-1. Download `woocommerce-local-pickup-time.zip`
-2. Extract the `woocommerce-local-pickup-time` directory to your computer
-3. Upload the `woocommerce-local-pickup-time` directory to the `/wp-content/plugins/` directory
+1. Download `woocommerce-local-pickup-time-select.zip`
+2. Extract the `woocommerce-local-pickup-time-select` directory to your computer
+3. Upload the `woocommerce-local-pickup-time-select` directory to the `/wp-content/plugins/` directory
 4. Activate the plugin in the Plugin dashboard
 
 === Usage ===

--- a/scripts/install-wp.sh
+++ b/scripts/install-wp.sh
@@ -19,4 +19,4 @@ wp option update permalink_structure "/%year%/%monthnum%/%postname%/" --skip-the
 wp plugin activate woocommerce
 
 # Activate plugin.
-wp plugin activate woocommerce-local-pickup-time-select
+wp plugin activate woocommerce-local-pickup-time-select-select

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -59,7 +59,7 @@ class WC_Local_Pickup_Time_Unit_Tests_Bootstrap {
 	 *
 	 * @var string
 	 */
-	protected $plugin_file = 'woocommerce-local-pickup-time.php';
+	protected $plugin_file = 'woocommerce-local-pickup-time-select.php';
 
 	/**
 	 * Composer installed WooCommerce source path.

--- a/woocommerce-local-pickup-time.php
+++ b/woocommerce-local-pickup-time.php
@@ -10,16 +10,16 @@
  *
  * @wordpress-plugin
  * Plugin Name:                WooCommerce Local Pickup Time Select
- * Plugin URI:                 https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time
+ * Plugin URI:                 https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select
  * Description:                Add an an option to WooCommerce checkout pages for Local Pickup that allows the user to choose a pickup time.
  * Version:                    1.3.13
  * Author:                     Tim Nolte
  * Author URI:                 https://www.ndigitals.com/
- * Text Domain:                woocommerce-local-pickup-time
+ * Text Domain:                woocommerce-local-pickup-time-select
  * License:                    GPL-2.0+
  * License URI:                http://www.gnu.org/licenses/gpl-2.0.txt
  * Domain Path:                /languages
- * GitHub Plugin URI:          https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time
+ * GitHub Plugin URI:          https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time-select
  * WC requires at least:       4.0.0
  * WC tested up to:            4.7.2
  */


### PR DESCRIPTION
Textdomain was wrong.

According to WordPress translation standars, textdomain have to be the same as plugin slug.

So `woocommerce-local-pickup-time` should be replaced by `woocommerce-local-pickup-time-select`




### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/pulls)) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #105 .

### How to test the changes in this Pull Request:

1. Set site locale to fr_FR
2. Go to Dashboard > Upgrades
3. Update translations



