### PR TITLE
Updates PHPStan Config to Not Fail on Unused Ignores

### DIFF
--- a/.github/workflows/pr-unit-testing.yml
+++ b/.github/workflows/pr-unit-testing.yml
@@ -61,8 +61,17 @@ jobs:
     - name: Require Specified WordPress Version
       run: composer require johnpbloch/wordpress-core:${{ matrix.wordpress-version }} --dev --prefer-source --update-with-all-dependencies
 
+    - name: Require Specified WordPress Stubs Version
+      run: composer require php-stubs/wordpress-stubs:${{ matrix.wordpress-version }} --dev --prefer-source --update-with-all-dependencies
+
+    - name: Require Specified WordPress PHPUnit Version
+      run: composer require wp-phpunit/wp-phpunit:${{ matrix.wordpress-version }} --dev --prefer-source --update-with-all-dependencies
+
     - name: Require Specified WooCommerce Version
       run: composer require wpackagist-plugin/woocommerce:${{ matrix.woocommerce-version }} --dev --prefer-source --update-with-all-dependencies
+
+    - name: Require Specified WooCommerce Stubs Version
+      run: composer require php-stubs/woocommerce-stubs:${{ matrix.woocommerce-version }} --dev --prefer-source --update-with-all-dependencies
 
     - name: Install Composer Dependencies
       run: composer install

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -104,6 +104,9 @@ jobs:
     - name: Require Specified WordPress Stubs Version
       run: composer require php-stubs/wordpress-stubs:${{ matrix.wordpress-version }} --dev --prefer-source --update-with-all-dependencies
 
+    - name: Require Specified WordPress PHPUnit Version
+      run: composer require wp-phpunit/wp-phpunit:${{ matrix.wordpress-version }} --dev --prefer-source --update-with-all-dependencies
+
     - name: Require Specified WooCommerce Version
       run: composer require woocommerce/woocommerce:${{ matrix.woocommerce-version }} --dev --prefer-source --update-with-all-dependencies
 

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,6 @@
 		"phpstan/phpstan": "~1.5.0",
 		"phpunit/phpunit": "^7",
 		"roave/security-advisories": "dev-master",
-		"sensiolabs/security-checker": "^5.0",
 		"squizlabs/php_codesniffer": "^3.3",
 		"szepeviktor/phpstan-wordpress": "^1.0",
 		"woocommerce/action-scheduler": "~3.4.0",
@@ -71,7 +70,7 @@
 		"woocommerce/woocommerce-blocks": "~7.3.0",
 		"woocommerce/woocommerce-sniffs": "~0.1.0",
 		"wp-coding-standards/wpcs": "^2.2",
-		"wp-phpunit/wp-phpunit": "~5.7.0",
+		"wp-phpunit/wp-phpunit": "~5.9.0",
 		"wpackagist-plugin/woocommerce": "~6.3.0"
 	},
 	"autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f48ff7b4d258b19ffb9d3c9518be774",
+    "content-hash": "0712f3e7529cad54e3491c2882056a67",
     "packages": [
         {
             "name": "composer/installers",
@@ -869,82 +869,6 @@
                 "source": "https://github.com/Brain-WP/BrainMonkey"
             },
             "time": "2021-11-11T15:53:55+00:00"
-        },
-        {
-            "name": "composer/ca-bundle",
-            "version": "1.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b",
-                "reference": "4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b",
-                "shasum": ""
-            },
-            "require": {
-                "ext-openssl": "*",
-                "ext-pcre": "*",
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^0.12.55",
-                "psr/log": "^1.0",
-                "symfony/phpunit-bridge": "^4.2 || ^5",
-                "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\CaBundle\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
-            "keywords": [
-                "cabundle",
-                "cacert",
-                "certificate",
-                "ssl",
-                "tls"
-            ],
-            "support": {
-                "irc": "irc://irc.freenode.org/composer",
-                "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.3.1"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-10-28T20:44:15+00:00"
         },
         {
             "name": "composer/pcre",
@@ -4484,57 +4408,6 @@
             "time": "2020-11-11T09:19:24+00:00"
         },
         {
-            "name": "sensiolabs/security-checker",
-            "version": "v5.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sensiolabs/security-checker.git",
-                "reference": "46be3f58adac13084497961e10eed9a7fb4d44d1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/46be3f58adac13084497961e10eed9a7fb4d44d1",
-                "reference": "46be3f58adac13084497961e10eed9a7fb4d44d1",
-                "shasum": ""
-            },
-            "require": {
-                "composer/ca-bundle": "^1.0",
-                "php": ">=5.5.9",
-                "symfony/console": "~2.7|~3.0|~4.0"
-            },
-            "bin": [
-                "security-checker"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "SensioLabs\\Security\\": "SensioLabs/Security"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien.potencier@gmail.com"
-                }
-            ],
-            "description": "A security checker for your composer.lock",
-            "support": {
-                "issues": "https://github.com/sensiolabs/security-checker/issues",
-                "source": "https://github.com/sensiolabs/security-checker/tree/master"
-            },
-            "abandoned": "https://github.com/fabpot/local-php-security-checker",
-            "time": "2018-12-19T17:14:59+00:00"
-        },
-        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.6.2",
             "source": {
@@ -6400,16 +6273,16 @@
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "5.7.4",
+            "version": "5.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
-                "reference": "d97ece673cc78aa9835f87d937f86b1bf8e0fc8c"
+                "reference": "ceece1ed4f2d0732c4a4f2603f4376d85547a50f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/d97ece673cc78aa9835f87d937f86b1bf8e0fc8c",
-                "reference": "d97ece673cc78aa9835f87d937f86b1bf8e0fc8c",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/ceece1ed4f2d0732c4a4f2603f4376d85547a50f",
+                "reference": "ceece1ed4f2d0732c4a4f2603f4376d85547a50f",
                 "shasum": ""
             },
             "type": "library",
@@ -6444,7 +6317,7 @@
                 "issues": "https://github.com/wp-phpunit/issues",
                 "source": "https://github.com/wp-phpunit/wp-phpunit"
             },
-            "time": "2021-11-10T19:49:28+00:00"
+            "time": "2022-02-22T20:53:17+00:00"
         },
         {
             "name": "wpackagist-plugin/woocommerce",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,7 @@ includes:
 parameters:
   level: max
   inferPrivatePropertyTypeFromConstructor: true
+  reportUnmatchedIgnoredErrors: false
   bootstrapFiles:
     - tests/phpstan-bootstrap.php
     - %rootDir%/../../php-stubs/wordpress-stubs/wordpress-stubs.php


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [plugin Contributing guideline](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/blob/master/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/WC-Local-Pickup/woocommerce-local-pickup-time/pulls)) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Fixes a PHPStan warning ignore issue with newer PHPStan.
- Fixes Composer package dependencies.
- Updates GitHub Actions for managing all WordPress & WooCommerce package version updates during runs.

### How to test the changes in this Pull Request:

1. Update PHPStan.
2. Run a code analysis.
3. Analysis should pass even if the ignored warning no longer exists.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
